### PR TITLE
Added more error reporting to the rspec compiler plugin

### DIFF
--- a/compiler/rspec.vim
+++ b/compiler/rspec.vim
@@ -20,6 +20,7 @@ set cpo-=C
 CompilerSet makeprg=spec
 
 CompilerSet errorformat=
+    \%-Z%f:%l:%.%#,%E%\\d%\\+)%.%#,%C%m,%Z,
     \%+W'%.%#'\ FAILED,
     \%+I'%.%#'\ FIXED,
     \%-Cexpected:%.%#,


### PR DESCRIPTION
Given a failure reported from rspec like so:
    1)
    NameError in 'this raises a name error'
    uninitialized constant Spec::Example::ExampleGroup::Subclass_1::Foo
    vim_vs_the_world_spec.rb:6:in `block (2 levels) in <top (required)>'

, the new line in the rspec compiler plugin picks up on these errors and report it properly.
