### PR TITLE
Pass v:lnum as an argument to GetRubyIndent

### DIFF
--- a/indent/eruby.vim
+++ b/indent/eruby.vim
@@ -50,7 +50,7 @@ function! GetErubyIndent(...)
   let inruby = searchpair('<%','','%>','W')
   call cursor(v:lnum,vcol)
   if inruby && getline(v:lnum) !~ '^<%\|^\s*[-=]\=%>'
-    let ind = GetRubyIndent()
+    let ind = GetRubyIndent(v:lnum)
   else
     exe "let ind = ".b:eruby_subtype_indentexpr
   endif


### PR DESCRIPTION
Instead of using `v:lnum` inside the indenting function, I think it would be better to pass it as an argument and use that. It shouldn't make a big difference code-wise, but it would (I think) help a lot with debugging. With this change, you could `call GetRubyIndent(line('.'))` directly and it won't be sandboxed. Right now, the [Decho](http://www.vim.org/scripts/script.php?script_id=120) script, for example, can't be used at all and any errors seem to be swallowed silently.
