### PR TITLE
Fix for the tooltip displayed on mouseover

### DIFF
--- a/ftplugin/ruby.vim
+++ b/ftplugin/ruby.vim
@@ -220,7 +220,7 @@ function! RubyBalloonexpr()
     if str !~ '^\w'
       return ''
     endif
-    silent! let res = substitute(system("ri -f simple -T \"".str.'"'),'\n$','','')
+    silent! let res = substitute(system("ri -f rdoc -T \"".str.'"'),'\n$','','')
     if res =~ '^Nothing known about' || res =~ '^Bad argument:' || res =~ '^More than one method'
       return ''
     endif


### PR DESCRIPTION
The balloon tooltip, which is displayed on mouseover, displays an error. I found a screenshot here: http://twitpic.com/499rsm, I can see the same. 

The tooltip is generated by `ri` by calling `ri -f simple -T <word>`. According to the ri documentation the only valid formats are ansi bs html rdoc (tested with ri 3.9.4). I tried all of them, `ansi` and `bs` displays some weird characters, `html` is not wanted here, the only usable is `rdoc`.
