### PR TITLE
Fix potential namespace collsion in ftplugin/ruby.vim

### DIFF
--- a/ftplugin/ruby.vim
+++ b/ftplugin/ruby.vim
@@ -68,7 +68,7 @@ if !exists("s:ruby_path")
     let s:ruby_path = type(g:ruby_path) == type([]) ? join(g:ruby_path,',') : g:ruby_path
   else
     if has("ruby") && has("win32")
-      ruby VIM::command( 'let s:ruby_paths = split("%s",",")' % $:.join(%q{,}) )
+      ruby ::VIM::command( 'let s:ruby_paths = split("%s",",")' % $:.join(%q{,}) )
     elseif executable('ruby')
       let s:code = "print $:.join(%q{,})"
       if executable('env') && $PATH !~# '\s'


### PR DESCRIPTION
On win32 installs with +ruby, ftplugin/ruby.vim makes a call to
VIM::command to set the s:ruby_paths variable. In some circumstances,
this code can run when under a different ruby module, and if that ruby
module has a VIM module defined, there is a namespace clash. The fix is
to change the call to be ::VIM::command, which works fine under all
cases. The conflict occurs with Command-T in particular when opening
a .rb file from that tool.
