### PR TITLE
Patch to fix indentation bug (lines after escaped paren in regex indented wrong)

### DIFF
--- a/indent/ruby.vim
+++ b/indent/ruby.vim
@@ -33,7 +33,7 @@ set cpo&vim
 " ============
 
 " Regex of syntax group names that are or delimit string or are comments.
-let s:syng_strcom = '\<ruby\%(Regexp\|RegexpDelimiter' .
+let s:syng_strcom = '\<ruby\%(Regexp\|RegexpDelimiter\|RegexpEscape' .
       \ '\|String\|StringEscape\|ASCIICode' .
       \ '\|Interpolation\|NoInterpolation\|Comment\|Documentation\)\>'
 


### PR DESCRIPTION
Fixed bug causing lines following an escaped parenthesis in a regex (/\(/) to be indented incorrectly.

To reproduce, put the following lines into a .rb file and indent the entire file:

a = /\(/
p "this line is now indented incorrectly"

If there's a better way to fix this bug, go for it. This is the solution I came to after spending about 15 minutes with the vim-ruby source.
