### PR TITLE
vim-ruby-install prompt to create a directory was misleading

### DIFF
--- a/bin/vim-ruby-install.rb
+++ b/bin/vim-ruby-install.rb
@@ -431,6 +431,7 @@ begin
     puts
     puts "Target directory '#{target_dir}' does not exist."
     response = Env.ask_user "Do you want to create it? [Yn] "
+    response = "y" if response.empty?
     if response.strip =~ /^y(es)?$/i
       FileUtils.mkdir_p(target_dir, :verbose => true)
     else


### PR DESCRIPTION
When target dir isn't found, prompt says "Do you want to create it? [Yn] ", implying yes is the default option. It then aborts instead of creating the dir. This commit fixes that.
