### PR TITLE
.gitignore for doc/tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags


### PR DESCRIPTION
doc/tags gets created by Pathogen when you follow the install
instructions for Command-t:

:call pathogen#helptags()

Other vim-\* plugins already explicitly ignore this file.
