### PR TITLE
Make the path to testrb in rubyunit.vim configurable

### DIFF
--- a/compiler/rubyunit.vim
+++ b/compiler/rubyunit.vim
@@ -17,7 +17,11 @@ endif
 let s:cpo_save = &cpo
 set cpo-=C
 
-CompilerSet makeprg=testrb
+if exists('testrb')
+    exec "CompilerSet makeprg=" . testrb
+else
+    CompilerSet makeprg=testrb
+endif
 
 CompilerSet errorformat=\%W\ %\\+%\\d%\\+)\ Failure:,
 			\%C%m\ [%f:%l]:,


### PR DESCRIPTION
"testrb" can have a version suffix (i.e. testrb1.8, testrb1.9.1). To allow the user to configure the path to it, this commit lets him set a global 'testrb' variable (which should be set before compiler is called).
