### PR TITLE
Add specs for indentation

### DIFF
--- a/spec/indentation_spec.rb
+++ b/spec/indentation_spec.rb
@@ -1,6 +1,11 @@
 require 'tempfile'
 require 'open3'
 
+# Each spec here contains an example of correctly-indented code. When the
+# expect_indent method runs Vim, it dedents all of the code then reindents it.
+# It passes only if it matches the correcty-indented code that the spec
+# originally gave it.
+
 describe "indentation" do
   it "indents nested definitions" do
     expect_indent %{


### PR DESCRIPTION
Prompted by @AndrewRadev's work fixing #86, I hacked together a quick POC of indentation specs. Doing this is pretty weird; Vim wasn't designed to be run as a stream editor, but that's what I'm making it do.

When you run them, Vim is constantly starting and exiting, so the screen flickers. This can be prevented by redirecting stdout/stderr to /dev/null. Sadly, that makes the specs slow since on each example it prints "Vim: Warning: Input is not from a terminal" and waits for a moment (not that you actually see that come out). Maybe that can be suppressed. Did I mention that doing this is weird?

Anyway! Is there any interest in something like this? I'm sure that this exact change is unacceptable for about a million reasons I don't understand, but maybe it's worth maintaining specs for parts of vim-ruby that are especially complex and regression-prone, like indentation?
