### PR TITLE
Fix escape_vim_singlequote_string

### DIFF
--- a/autoload/rubycomplete.vim
+++ b/autoload/rubycomplete.vim
@@ -365,7 +365,7 @@ class VimRubyCompletion
   end
 
   def escape_vim_singlequote_string(str)
-    str.gsub(/'/,"\\'")
+    str.to_s.gsub(/'/,"\\'")
   end
 
   def get_buffer_entity_list( type )


### PR DESCRIPTION
str argument is Symbol from Object.instance_methods etc,
and Symbol is undefined `#gsub`.
