### PR TITLE
Added support for YARD todos.

### DIFF
--- a/syntax/ruby.vim
+++ b/syntax/ruby.vim
@@ -270,7 +270,7 @@ endif
 
 " Comments and Documentation
 syn match   rubySharpBang "\%^#!.*" display
-syn keyword rubyTodo	  FIXME NOTE TODO OPTIMIZE XXX contained
+syn keyword rubyTodo	  FIXME NOTE TODO OPTIMIZE XXX todo contained
 syn match   rubyComment   "#.*" contains=rubySharpBang,rubySpaceError,rubyTodo,@Spell
 if !exists("ruby_no_comment_fold")
   syn region rubyMultilineComment start="\%(\%(^\s*#.*\n\)\@<!\%(^\s*#.*\n\)\)\%(\(^\s*#.*\n\)\{1,}\)\@=" end="\%(^\s*#.*\n\)\@<=\%(^\s*#.*\n\)\%(^\s*#\)\@!" contains=rubyComment transparent fold keepend


### PR DESCRIPTION
Hi, 

this is a very tiny patch that adds support for the `@todo` tag of [YARD](http://yardoc.org). My understanding of the vim script language is very limited and I'm not sure how to include the `@`.
