### PR TITLE
disable ansi color for keyword lookup with `ri` in GUI

### DIFF
--- a/ftplugin/ruby.vim
+++ b/ftplugin/ruby.vim
@@ -15,7 +15,7 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 if has("gui_running") && !has("gui_win32")
-  setlocal keywordprg=ri\ -T
+  setlocal keywordprg=ri\ -T\ -f\ bs
 else
   setlocal keywordprg=ri
 endif


### PR DESCRIPTION
GUI Vim doesn't support displaying ansi-colored output from commands,
but `ri` defaults to color. This explicitly disables that.

In non-GUI vim, colors display just fine so that isn't touched.
