### PR TITLE
a:v -> escape(a:v) in GetRubyVarType for *args

### DIFF
--- a/autoload/rubycomplete.vim
+++ b/autoload/rubycomplete.vim
@@ -133,7 +133,7 @@ function! s:GetRubyVarType(v)
     let stopline = 1
     let vtp = ''
     let pos = getpos('.')
-    let sstr = '^\s*#\s*@var\s*'.a:v.'\>\s\+[^ \t]\+\s*$'
+    let sstr = '^\s*#\s*@var\s*'.escape(a:v, '*').'\>\s\+[^ \t]\+\s*$'
     let [lnum,lcol] = searchpos(sstr,'nb',stopline)
     if lnum != 0 && lcol != 0
         call setpos('.',pos)


### PR DESCRIPTION
completion for '_args.' or '(_args).' was causing error, so I escaped the asterisk.
