### PR TITLE
Make matchit's "%" ignore Range.end method

### DIFF
--- a/syntax/ruby.vim
+++ b/syntax/ruby.vim
@@ -228,7 +228,7 @@ if !exists("b:ruby_no_expensive") && !exists("ruby_no_expensive")
   " statements without 'do'
   syn region rubyBlockExpression       matchgroup=rubyControl	  start="\<begin\>" end="\<end\>" contains=ALLBUT,@rubyNotTop fold
   syn region rubyCaseExpression	       matchgroup=rubyConditional start="\<case\>"  end="\<end\>" contains=ALLBUT,@rubyNotTop fold
-  syn region rubyConditionalExpression matchgroup=rubyConditional start="\%(\%(^\|\.\.\.\=\|[{:,;([<>~\*/%&^|+=-]\|\%(\<[_[:lower:]][_[:alnum:]]*\)\@<![?!]\)\s*\)\@<=\%(if\|unless\)\>" end="\<end\>" contains=ALLBUT,@rubyNotTop fold
+  syn region rubyConditionalExpression matchgroup=rubyConditional start="\%(\%(^\|\.\.\.\=\|[{:,;([<>~\*/%&^|+=-]\|\%(\<[_[:lower:]][_[:alnum:]]*\)\@<![?!]\)\s*\)\@<=\%(if\|unless\)\>" end="\%(\%(\%(\.\@<!\.\)\|::\)\s*\)\@<!\<end\>" contains=ALLBUT,@rubyNotTop fold
 
   syn match rubyConditional "\<\%(then\|else\|when\)\>[?!]\@!"	contained containedin=rubyCaseExpression
   syn match rubyConditional "\<\%(then\|else\|elsif\)\>[?!]\@!" contained containedin=rubyConditionalExpression


### PR DESCRIPTION
With the following code, matchit's "%" key will now jump between line 1
and line 3, as it should:

``` ruby
if x
  (1..5).end
end
```

Ruby allows methods with keyword names, such as "end".  That was confusing Vim's "%" command (go to match), since the `end` in `(1..5).end` looks like a keyword.

The fix is similar to what is done farther down in `syntax/ruby.vim`, in the section that defines `rubyKeywordAsMethod`: If "end" is preceded by "." or "::", then it is a method name.
