### PR TITLE
Add support for public_constant & private_constant (added in Ruby 1.9.3)

### DIFF
--- a/syntax/ruby.vim
+++ b/syntax/ruby.vim
@@ -255,7 +255,7 @@ endif
 
 " Special Methods
 if !exists("ruby_no_special_methods")
-  syn keyword rubyAccess    public protected private public_class_method private_class_method module_function
+  syn keyword rubyAccess    public protected private public_class_method private_class_method public_constant private_constant module_function
   " attr is a common variable name
   syn match   rubyAttribute "\%(\%(^\|;\)\s*\)\@<=attr\>\(\s*[.=]\)\@!"
   syn keyword rubyAttribute attr_accessor attr_reader attr_writer


### PR DESCRIPTION
`private_constant` & `public_constant` were [added in Ruby 1.9.3](http://svn.ruby-lang.org/repos/ruby/tags/v1_9_3_0/NEWS), so add support for them.
