### PR TITLE
Highlight unicode characters in constants

### DIFF
--- a/syntax/ruby.vim
+++ b/syntax/ruby.vim
@@ -92,7 +92,7 @@ syn match rubyFloat	"\%(\%(\w\|[]})\"']\s*\)\@<!-\)\=\<\%(0\|[1-9]\d*\%(_\d\+\)*
 syn match rubyLocalVariableOrMethod "\<[_[:lower:]][_[:alnum:]]*[?!=]\=" contains=NONE display transparent
 syn match rubyBlockArgument	    "&[_[:lower:]][_[:alnum:]]"		 contains=NONE display transparent
 
-syn match  rubyConstant		"\%(\%(^\|[^.]\)\.\_s*\)\@<!\<\u\w*\>\%(\s*(\)\@!"
+syn match  rubyConstant		"\%(\%(^\|[^.]\)\.\_s*\)\@<!\<\u\%(\w\|[^\x00-\x7F]\)*\>\%(\s*(\)\@!"
 syn match  rubyClassVariable	"@@\%(\h\|[^\x00-\x7F]\)\%(\w\|[^\x00-\x7F]\)*" display
 syn match  rubyInstanceVariable "@\%(\h\|[^\x00-\x7F]\)\%(\w\|[^\x00-\x7F]\)*"  display
 syn match  rubyGlobalVariable	"$\%(\%(\h\|[^\x00-\x7F]\)\%(\w\|[^\x00-\x7F]\)*\|-.\)"


### PR DESCRIPTION
#138 forgot about constants, and this remedies that mistake. Ruby doesn’t allow unicode characters as the first character of a constant (as shown by the below script), so we only highlight constants which have unicode characters as their second or later letter. I separately validated that all valid unicode characters are allowed (with a trivial modification of this script).

``` ruby
unicode_codepoints = 0x80..0x10FFFF

valid_codepoints = unicode_codepoints.select do |codepoint|
  str = [codepoint].pack 'U'
  begin
    eval "class #{str}; end"
  rescue SyntaxError
    false
  else
    true
  end
end

valid_codepoints  #=> []
```
