### PR TITLE
Proposal - optional indent after private / protected?

### DIFF
--- a/indent/ruby.vim
+++ b/indent/ruby.vim
@@ -51,13 +51,13 @@ let s:skip_expr =
 " Regex used for words that, at the start of a line, add a level of indent.
 let s:ruby_indent_keywords = '^\s*\zs\<\%(module\|class\|def\|if\|for' .
       \ '\|while\|until\|else\|elsif\|case\|when\|unless\|begin\|ensure' .
-      \ '\|rescue\):\@!\>' .
+      \ '\|rescue\|private\|protected):\@!\>' .
       \ '\|\%([=,*/%+-]\|<<\|>>\|:\s\)\s*\zs' .
       \    '\<\%(if\|for\|while\|until\|case\|unless\|begin\):\@!\>'
 
 " Regex used for words that, at the start of a line, remove a level of indent.
 let s:ruby_deindent_keywords =
-      \ '^\s*\zs\<\%(ensure\|else\|rescue\|elsif\|when\|end\):\@!\>'
+      \ '^\s*\zs\<\%(private\|protected\|ensure\|else\|rescue\|elsif\|when\|end\):\@!\>'
 
 " Regex that defines the start-match for the 'end' keyword.
 "let s:end_start_regex = '\%(^\|[^.]\)\<\%(module\|class\|def\|if\|for\|while\|until\|case\|unless\|begin\|do\)\>'


### PR DESCRIPTION
Hey all,

I know there's an open debate about this indentation style, but what does everyone think about having an optional configuration for indenting after single line private / protected statements?

It's listed as a code convention in the [rails guide](http://edgeguides.rubyonrails.org/contributing_to_ruby_on_rails.html#follow-the-coding-conventions) and is used by the team I work on as the expected style.

The attached changes are what I've monkey-patched in order to get this indentation working, but would someone more fluent in viml / writing regex be able to implement a better solution? What this breaks is when a `private :method` declaration is used.

It'd be great if I could just add `let g:vim_ruby_indent_private_protected = 1` to my .vimrc to toggle this behavior.

Cheers,
D
