### PR TITLE
Add CocoaPods file type detection

### DIFF
--- a/ftdetect/ruby.vim
+++ b/ftdetect/ruby.vim
@@ -59,4 +59,7 @@ au BufNewFile,BufRead [Bb]uildfile		set filetype=ruby
 " Appraisal
 au BufNewFile,BufRead Appraisals		set filetype=ruby
 
+" CocoaPods
+au BufNewFile,BufRead Podfile,*.podspec		set filetype=ruby
+
 " vim: nowrap sw=2 sts=2 ts=8 noet:


### PR DESCRIPTION
[CocoaPods](http://cocoapods.org/) is to Objective-C what RubyGems and Bundler are to Ruby. It, too, uses Ruby as the language for its dependency declaration (`Podfile`) and package specification (`*.podspec`) files. Treat these as Ruby files.
