### PR TITLE
Add syntax detection for .ruby (Rails 4)

### DIFF
--- a/ftdetect/ruby.vim
+++ b/ftdetect/ruby.vim
@@ -2,7 +2,7 @@
 au BufNewFile,BufRead *.rb,*.rbw,*.gemspec	set filetype=ruby
 
 " Ruby on Rails
-au BufNewFile,BufRead *.builder,*.rxml,*.rjs	set filetype=ruby
+au BufNewFile,BufRead *.builder,*.rxml,*.rjs,*.ruby	set filetype=ruby
 
 " Rakefile
 au BufNewFile,BufRead [rR]akefile,*.rake	set filetype=ruby


### PR DESCRIPTION
In Rails 4.x .ruby extension was added as template handler
ref https://github.com/rails/rails/commit/de1060f4e02925c12004f2
