### PR TITLE
added __dir__ to rubyPseudoVariable list

### DIFF
--- a/syntax/ruby.vim
+++ b/syntax/ruby.vim
@@ -197,7 +197,7 @@ syn match   rubyControl	       "\<\%(and\|break\|in\|next\|not\|or\|redo\|rescue
 syn match   rubyOperator       "\<defined?" display
 syn match   rubyKeyword	       "\<\%(super\|yield\)\>[?!]\@!"
 syn match   rubyBoolean	       "\<\%(true\|false\)\>[?!]\@!"
-syn match   rubyPseudoVariable "\<\%(nil\|self\|__ENCODING__\|__FILE__\|__LINE__\|__callee__\|__method__\)\>[?!]\@!" " TODO: reorganise
+syn match   rubyPseudoVariable "\<\%(nil\|self\|__ENCODING__\|__dir__\|__FILE__\|__LINE__\|__callee__\|__method__\)\>[?!]\@!" " TODO: reorganise
 syn match   rubyBeginEnd       "\<\%(BEGIN\|END\)\>[?!]\@!"
 
 " Expensive Mode - match 'end' with the appropriate opening keyword for syntax


### PR DESCRIPTION
Ruby 2.0 added Kernel#__dir__ (which is essentially a shortcut for `File.dirname(File.realpath(__FILE__))`).

This change adds __dir__ to the same highlight list as __FILE__, __LINE__, __callee__ and other similarly named functions.
