### PR TITLE
Add support to *.cap files

### DIFF
--- a/ftdetect/ruby.vim
+++ b/ftdetect/ruby.vim
@@ -26,7 +26,7 @@ au BufNewFile,BufRead .pryrc			call s:setf('ruby')
 au BufNewFile,BufRead *.ru			call s:setf('ruby')
 
 " Capistrano
-au BufNewFile,BufRead Capfile			call s:setf('ruby')
+au BufNewFile,BufRead Capfile,*.cap 		call s:setf('ruby')
 
 " Bundler
 au BufNewFile,BufRead Gemfile			call s:setf('ruby')


### PR DESCRIPTION
I felt necessity some time ago to `vim-ruby` support `*.cap` files. I added this as a personal configuration, but I found myself too selfish and think this would be helpful to everyone. :smile: 
