### PR TITLE
Add syntax detection for Routefile

### DIFF
--- a/ftdetect/ruby.vim
+++ b/ftdetect/ruby.vim
@@ -68,4 +68,7 @@ au BufNewFile,BufRead Appraisals		call s:setf('ruby')
 " CocoaPods
 au BufNewFile,BufRead Podfile,*.podspec		call s:setf('ruby')
 
+" Routefile
+au BufNewFile,BufRead [rR]outefile		call s:setf('ruby')
+
 " vim: nowrap sw=2 sts=2 ts=8 noet:


### PR DESCRIPTION
`Routefile` is the standard file for [Roadworker](https://github.com/winebarrel/roadworker). Roadworker is a tool to manage Route53. It defines the state of Route53 using DSL, and updates Route53 according to DSL.

It would be great to have this in vim-ruby.