### PR TITLE
Move reading count at the begining of searchsyn

### DIFF
--- a/ftplugin/ruby.vim
+++ b/ftplugin/ruby.vim
@@ -277,12 +277,12 @@ function! RubyBalloonexpr()
 endfunction
 
 function! s:searchsyn(pattern,syn,flags,mode)
+  let cnt = v:count1
   norm! m'
   if a:mode ==# 'v'
     norm! gv
   endif
   let i = 0
-  let cnt = v:count ? v:count : 1
   while i < cnt
     let i = i + 1
     let line = line('.')


### PR DESCRIPTION
In a ruby program with more than one function, typing 2]m would jump to the first beginning of method, not the second one, as expected. This is because, in searchsyn v:count is read after other commands are run. This leads to count being ignored for all the method jumps.

This change moves initialization of cnt variable in searchsyn to the beginning of the method, and also uses v:count1.
