### PR TITLE
Fix eruby indentation when 'shiftwidth' is 0

### DIFF
--- a/indent/eruby.vim
+++ b/indent/eruby.vim
@@ -42,6 +42,13 @@ if exists("*GetErubyIndent")
 endif
 
 function! GetErubyIndent(...)
+  " The value of a single shift-width
+  if exists('*shiftwidth')
+    let sw = shiftwidth()
+  else
+    let sw = &sw
+  endif
+
   if a:0 && a:1 == '.'
     let v:lnum = line('.')
   elseif a:0 && a:1 =~ '^\d'
@@ -70,24 +77,24 @@ function! GetErubyIndent(...)
   let line = getline(lnum)
   let cline = getline(v:lnum)
   if cline =~# '^\s*<%[-=]\=\s*\%(}\|end\|else\|\%(ensure\|rescue\|elsif\|when\).\{-\}\)\s*\%([-=]\=%>\|$\)'
-    let ind = ind - &sw
+    let ind = ind - sw
   endif
   if line =~# '\S\s*<%[-=]\=\s*\%(}\|end\).\{-\}\s*\%([-=]\=%>\|$\)'
-    let ind = ind - &sw
+    let ind = ind - sw
   endif
   if line =~# '\%({\|\<do\)\%(\s*|[^|]*|\)\=\s*[-=]\=%>'
-    let ind = ind + &sw
+    let ind = ind + sw
   elseif line =~# '<%[-=]\=\s*\%(module\|class\|def\|if\|for\|while\|until\|else\|elsif\|case\|when\|unless\|begin\|ensure\|rescue\)\>.*%>'
-    let ind = ind + &sw
+    let ind = ind + sw
   endif
   if line =~# '^\s*<%[=#-]\=\s*$' && cline !~# '^\s*end\>'
-    let ind = ind + &sw
+    let ind = ind + sw
   endif
   if line !~# '^\s*<%' && line =~# '%>\s*$'
-    let ind = ind - &sw
+    let ind = ind - sw
   endif
   if cline =~# '^\s*[-=]\=%>\s*$'
-    let ind = ind - &sw
+    let ind = ind - sw
   endif
   return ind
 endfunction


### PR DESCRIPTION
For [#239, Indentation fails when 'shiftwidth' is 0](https://github.com/vim-ruby/vim-ruby/issues/239)

This change is based on the commit [Set correct "shiftwidth" value](https://github.com/vim-ruby/vim-ruby/commit/9d95f296a7afde76361130217304d75004c0d8f9). That change only fixes Ruby files, not `.erb` files. I tested indenting an erb file, and saw that indentation didn’t work before this change and does work after this change.
