### PR TITLE
Added config for param indentation.

### DIFF
--- a/doc/vim-ruby.txt
+++ b/doc/vim-ruby.txt
@@ -110,6 +110,27 @@ Access modifier style "outdent":
   public
     def method; end
   end
-<
+
+==============================================================================
+4. Parameter Indentation                   *ruby-parameter-indentation*
+                                           *g:ruby_indent_param_style*
+
+Different styles for parameter indentation can be set by using
+g:ruby_indent_param_style:
+
+	:let g:ruby_indent_param_style = 'param'
+	:let g:ruby_indent_param_style = 'line'
+	
+By default, the "param" indentation style is used:
+
+Parameter indentation style "param":
+>
+some_method(arg1,
+            arg2)
+
+Parameter indentation style "line":
+
+some_method(arg1,
+  arg2)
 
  vim:tw=78:sw=4:ts=8:ft=help:norl:

--- a/indent/ruby.vim
+++ b/indent/ruby.vim
@@ -18,6 +18,11 @@ if !exists('g:ruby_indent_access_modifier_style')
   let g:ruby_indent_access_modifier_style = 'normal'
 endif
 
+if !exists('g:ruby_indent_param_style')
+  " Possible values: "param", "line"
+  let g:ruby_indent_param_style = "param"
+endif
+
 setlocal nosmartindent
 
 " Now, set up our indentation expression and keys that trigger it.
@@ -533,7 +538,7 @@ function GetRubyIndent(...)
 
     if opening.pos != -1
       if opening.type == '(' && searchpair('(', '', ')', 'bW', s:skip_expr) > 0
-        if col('.') + 1 == col('$')
+        if col('.') + 1 == col('$') || g:ruby_indent_param_style == "line"
           return ind + sw
         else
           return virtcol('.')


### PR DESCRIPTION
Currently vim-ruby aligns parameter lists containing line breaks with the first parameter in the parameter list, but our team's style guide calls for aligning using a standard indent on the next line instead, so I end up cleaning up lines any time I have a line break in a method call or definition. This PR adds the g:ruby_indent_param_style option with two possible values, "param" or "line", to make indentation within parameter lists configurable.