### PR TITLE
Try to obtain Ruby version from rbenv (if present).

### DIFF
--- a/ftplugin/ruby.vim
+++ b/ftplugin/ruby.vim
@@ -107,6 +107,11 @@ if !exists('b:ruby_version') && !exists('g:ruby_path') && isdirectory(expand('%:
     if !has_key(g:ruby_version_paths, b:ruby_version)
       let g:ruby_version_paths[b:ruby_version] = s:query_path(fnamemodify(s:version_file, ':p:h'))
     endif
+  else
+    let b:rbenv_version = system('rbenv version-name')
+    if !empty(b:rbenv_version)
+      let b:ruby_version = substitute(b:rbenv_version,'\n','','')
+    end
   endif
 endif
 


### PR DESCRIPTION
This is a simple patch to make vim-ruby try to obtain b:ruby_version directly from rbenv.