### PR TITLE
Include ? and ! as part of keyword.

### DIFF
--- a/ftplugin/ruby.vim
+++ b/ftplugin/ruby.vim
@@ -19,6 +19,9 @@ else
   setlocal keywordprg=ri
 endif
 
+" Ruby methods can include ? and ! so treat them as part of a keyword.
+setlocal iskeyword=@,!,?,48-57,_,192-255
+
 " Matchit support
 if exists("loaded_matchit") && !exists("b:match_words")
   let b:match_ignorecase = 0


### PR DESCRIPTION
This means that, with your cursor somewhere near the method call:

    password_required?

you can hit `ctrl-]` and it will jump to the correct definition, which makes me
unreasonably happy!