### PR TITLE
ftplugin: Add '!' and '?' in `&l:iskeysword`

### DIFF
--- a/ftplugin/ruby.vim
+++ b/ftplugin/ruby.vim
@@ -46,6 +46,7 @@ setlocal formatoptions-=t formatoptions+=croql
 setlocal include=^\\s*\\<\\(load\\>\\\|require\\>\\\|autoload\\s*:\\=[\"']\\=\\h\\w*[\"']\\=,\\)
 setlocal includeexpr=substitute(substitute(v:fname,'::','/','g'),'$','.rb','')
 setlocal suffixesadd=.rb
+setlocal iskeyword+=! iskeyword+=?
 
 if exists("&ofu") && has("ruby")
   setlocal omnifunc=rubycomplete#Complete


### PR DESCRIPTION
This prevents vim ignore the end of methods names.