### PR TITLE
Add HACK and REVIEW as comment annotations

### DIFF
--- a/syntax/ruby.vim
+++ b/syntax/ruby.vim
@@ -284,7 +284,7 @@ endif
 
 " Comments and Documentation
 syn match   rubySharpBang "\%^#!.*" display
-syn keyword rubyTodo	  FIXME NOTE TODO OPTIMIZE XXX todo contained
+syn keyword rubyTodo	  FIXME NOTE TODO OPTIMIZE HACK REVIEW XXX todo contained
 syn match   rubyComment   "#.*" contains=rubySharpBang,rubySpaceError,rubyTodo,@Spell
 if !exists("ruby_no_comment_fold")
   syn region rubyMultilineComment start="\%(\%(^\s*#.*\n\)\@<!\%(^\s*#.*\n\)\)\%(\(^\s*#.*\n\)\{1,}\)\@=" end="\%(^\s*#.*\n\)\@<=\%(^\s*#.*\n\)\%(^\s*#\)\@!" contains=rubyComment transparent fold keepend


### PR DESCRIPTION
These have made it into the community style guide here:

https://github.com/bbatsov/ruby-style-guide#comment-annotations

So it would be great to add highlighting for these.