### PR TITLE
Don't highlight `.?c` as a "character" literal.

### DIFF
--- a/syntax/ruby.vim
+++ b/syntax/ruby.vim
@@ -80,7 +80,7 @@ syn cluster rubyExtendedStringSpecial contains=@rubyStringSpecial,rubyNestedPare
 syn cluster rubyRegexpSpecial	      contains=rubyInterpolation,rubyNoInterpolation,rubyStringEscape,rubyRegexpSpecial,rubyRegexpEscape,rubyRegexpBrackets,rubyRegexpCharClass,rubyRegexpDot,rubyRegexpQuantifier,rubyRegexpAnchor,rubyRegexpParens,rubyRegexpComment
 
 " Numbers and ASCII Codes
-syn match rubyASCIICode	"\%(\w\|[]})\"'/]\)\@<!\%(?\%(\\M-\\C-\|\\C-\\M-\|\\M-\\c\|\\c\\M-\|\\c\|\\C-\|\\M-\)\=\%(\\\o\{1,3}\|\\x\x\{1,2}\|\\\=\S\)\)"
+syn match rubyASCIICode	"\%(\w\|[]})\"'/\.]\)\@<!\%(?\%(\\M-\\C-\|\\C-\\M-\|\\M-\\c\|\\c\\M-\|\\c\|\\C-\|\\M-\)\=\%(\\\o\{1,3}\|\\x\x\{1,2}\|\\\=\S\)\)"
 syn match rubyInteger	"\%(\%(\w\|[]})\"']\s*\)\@<!-\)\=\<0[xX]\x\+\%(_\x\+\)*\>"								display
 syn match rubyInteger	"\%(\%(\w\|[]})\"']\s*\)\@<!-\)\=\<\%(0[dD]\)\=\%(0\|[1-9]\d*\%(_\d\+\)*\)\>"						display
 syn match rubyInteger	"\%(\%(\w\|[]})\"']\s*\)\@<!-\)\=\<0[oO]\=\o\+\%(_\o\+\)*\>"								display


### PR DESCRIPTION
`.?`, the "safe navigation operator", [has been accepted into Ruby](https://github.com/ruby/ruby/commit/a356fe1c3550892902103f66928426ac8279e072) and
presently conflicts with the rule for highlighting `?c` character
literals. This patch remedies the issue by adding `\.` to the class of
preceding characters which refute such a match.

I refrained from adding `.?` to `rubyOperator` only for symmetry with
the absence of `.` therein, but `.?` is sufficiently "weird" as to be
worth considering making an exception for; it's the sort of thing that
really ought to stand out, in my estimation.

That `::` can be used for method invocation seems to have been largely
forgotten, but I suspect `::?` will eventually find its way in, at which
time another patch very much like this one will be necessitated.