### PR TITLE
Fix broken mappings when ruby_no_expensive exists

### DIFF
--- a/syntax/ruby.vim
+++ b/syntax/ruby.vim
@@ -258,11 +258,11 @@ if !exists("b:ruby_no_expensive") && !exists("ruby_no_expensive")
   exec "syn sync minlines=" . ruby_minlines
 
 else
-  syn match rubyControl "\<def\>[?!]\@!"    nextgroup=rubyMethodDeclaration skipwhite skipnl
-  syn match rubyControl "\<class\>[?!]\@!"  nextgroup=rubyClassDeclaration  skipwhite skipnl
-  syn match rubyControl "\<module\>[?!]\@!" nextgroup=rubyModuleDeclaration skipwhite skipnl
+  syn match rubyClass   "\<class\>[?!]\@!"  nextgroup=rubyClassDeclaration  skipwhite skipnl
+  syn match rubyModule  "\<module\>[?!]\@!" nextgroup=rubyModuleDeclaration skipwhite skipnl
+  syn match rubyDefine  "\<def\>[?!]\@!"    nextgroup=rubyMethodDeclaration skipwhite skipnl
   syn match rubyControl "\<\%(case\|begin\|do\|for\|if\|unless\|while\|until\|else\|elsif\|ensure\|then\|when\|end\)\>[?!]\@!"
-  syn match rubyKeyword "\<\%(alias\|undef\)\>[?!]\@!"
+  syn match rubyDefine  "\<\%(alias\|undef\)\>[?!]\@!"
 endif
 
 " Special Methods


### PR DESCRIPTION
The syntax groups for `def`, `undef`, `alias`, `class`, and `module` change depending on whether or not `ruby_no_expensive` exists.  This breaks mappings like `[m` and `[[` which rely on syntax groups to jump to the method/class definition.

Currently if `ruby_no_expensive` exists the syntax group for `def` is rubyControl but `[m` will only jump to a "def" if it belongs to the syntax group rubyDefine.

This won't fix all mappings.  For example, `[M` is still broken because `end` can't be matched to the syntax group rubyDefine without doing some of the more expensive syntax matching, but it should at least restore some of the lost functionality.  

Whether restoring half is better than nothing is subjective, but I find it useful especially since I find `[m` generally more useful than `[M`.  Additionally, a lot of the lost functionality can be regained by using the `%` command in conjunction with the fix in this patch (i.e. `]M` is equivalent to `[m%`)

Some lines are moved around to try and remain as true to the style of the script as possible, but the only change is the syntax groups themselves.

One of the main downsides of this change is probably that a `def` and its matching `end` won't be highlighted with the same colors when `ruby_no_expensive` is set.  I don't think there's really an easy way around it, and can probably be lumped in with the other tradeoffs of setting `ruby_no_expensive` in the first place.
