### PR TITLE
Add support for RSpec 3.4 to compiler

### DIFF
--- a/compiler/rspec.vim
+++ b/compiler/rspec.vim
@@ -25,6 +25,7 @@ CompilerSet errorformat=
     \%-Z\ \ \ \ \ %\\+\#\ %f:%l:%.%#,
     \%E\ \ %\\d%\\+)%.%#,
     \%C\ \ \ \ \ %m,
+    \%C%\\s%#,
     \%-G%.%#
 
 let &cpo = s:cpo_save


### PR DESCRIPTION
RSpec 3.4 introduced a small change to its failure messages. Given the following spec file:

```ruby
RSpec.describe "blah" do
  it "definitely does not raise hell" do
    raise "hell"
  end
end
```

RSpec 3.3 outputs:

    blah
      definitely does not raise hell (FAILED - 1)

    Failures:

      1) blah definitely does not raise hell
        Failure/Error: raise "hell"
        RuntimeError:
          hell
        # ./blah_spec.rb:3:in `block (2 levels) in <top (required)>'
    <snip>

RSpec 3.4 outputs:

    blah
      definitely does not raise hell (FAILED - 1)

    Failures:

      1) blah definitely does not raise hell
        Failure/Error: raise "hell"

        RuntimeError:
          hell
        # ./blah_spec.rb:3:in `block (2 levels) in <top (required)>'
    <snip>

This change adds a multi-line continuation rule to the RSpec compiler allowing it to ignore empty lines in multi-line error messages.

In dispatch.vim this is the difference between this:

![20151210-2bmhe](https://cloud.githubusercontent.com/assets/383376/11728168/2e905bf2-9f80-11e5-8008-f5fc68f637a5.png)

...and this:

![20151210-6qwhz](https://cloud.githubusercontent.com/assets/383376/11728188/4e5703dc-9f80-11e5-8b85-b21cb5aeaf9f.png)

---

Edit: FWIW I wondered whether this might be a bug in RSpec, but the change was introduced [here](https://github.com/rspec/rspec-core/commit/b98c63890d78dc8e27134635ce1fdd78cd0bc70d), so would appear to be deliberate.
