### PR TITLE
Match much more complicated structures in block's arguments in a very simple way.

### DIFF
--- a/indent/ruby.vim
+++ b/indent/ruby.vim
@@ -123,7 +123,7 @@ let s:indent_access_modifier_regex = '\C^\s*\%(protected\|private\)\s*\%(#.*\)\=
 " The reason is that the pipe matches a hanging "|" operator.
 "
 let s:block_regex =
-      \ '\%(\<do:\@!\>\|%\@<!{\)\s*\%(|\s*(*\s*\%([*@&]\=\h\w*,\=\s*\)\%(,\s*(*\s*[*@&]\=\h\w*\s*)*\s*\)*|\)\=\s*\%(#.*\)\=$'
+      \ '\%(\<do:\@!\>\|%\@<!{\)\s*\%(|[^|]*|\)\=\s*\%(#.*\)\=$'
 
 let s:block_continuation_regex = '^\s*[^])}\t ].*'.s:block_regex
 

--- a/spec/indent/blocks_spec.rb
+++ b/spec/indent/blocks_spec.rb
@@ -82,4 +82,18 @@ describe "Indenting" do
       end
     EOF
   end
+
+  specify "blocks with default arguments" do
+    assert_correct_indenting <<-EOF
+      proc do |a = 1|
+        puts a
+      end
+    EOF
+
+    assert_correct_indenting <<-EOF
+      proc do |a: "asdf", b:|
+        puts a, b
+      end
+    EOF
+  end
 end


### PR DESCRIPTION
All of the tests pass. It simplifies matching blocks a lot. And it fixes indenting blocks with arguments that have default values.