### PR TITLE
Add configurable block style indentation

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -16,3 +16,4 @@ Other contributors:
 	Gavin Sinclair <gsinclair@gmail.com>
 	Aaron Son <aaronson@uiuc.edu>
 	Ned Konz <ned@bike-nomad.com>
+  Pan Thomakos <pan.thomakos@gmail.com>

--- a/doc/vim-ruby.txt
+++ b/doc/vim-ruby.txt
@@ -3,7 +3,7 @@
 1. Ruby motions				|ruby-motion|
 2. Ruby text objects			|ruby-text-objects|
 3. Access modifier indentation		|ruby-access-modifier-indentation|
-
+4. Block style indentation		|ruby-block-indentation|
 
 ==============================================================================
 1. Ruby motions						*ruby-motion*
@@ -110,6 +110,32 @@ Access modifier style "outdent":
   public
     def method; end
   end
+<
+
+==============================================================================
+4. Block style indentation                      *ruby-block-style-indentation*
+                                                *g:ruby_indent_block_style*
+
+Different block indentation styles can be used by setting: >
+
+	:let g:ruby_indent_block_style = 'expression'
+	:let g:ruby_indent_block_style = 'do'
+<
+By default, the "expression" block indent style is used.
+
+Block indent style "expression":
+>
+  first
+    .second do |x|
+    something
+  end
+<
+Block indent style "do":
+>
+  first
+    .second do |x|
+      something
+    end
 <
 
  vim:tw=78:sw=4:ts=8:ft=help:norl:

--- a/spec/indent/blocks_spec.rb
+++ b/spec/indent/blocks_spec.rb
@@ -1,6 +1,62 @@
 require 'spec_helper'
 
 describe "Indenting" do
+  after :each do
+    vim.command 'let g:ruby_indent_block_style = "expression"'
+  end
+
+  specify "indented blocks with expression style" do
+    vim.command 'let g:ruby_indent_block_style = "expression"'
+
+    assert_correct_indenting <<-EOF
+        a
+          .b do |x|
+          something
+        end
+    EOF
+
+    assert_correct_indenting <<-EOF
+      a
+        .b { |x|
+        something
+      }
+    EOF
+  end
+
+  specify "indented blocks with do style" do
+    vim.command 'let g:ruby_indent_block_style = "do"'
+
+    assert_correct_indenting <<-EOF
+        a
+          .b do |x|
+            something
+          end
+    EOF
+
+    # Check that "do" style indentation does not mess up indentation
+    # following the bock.
+    assert_correct_indenting <<-EOF
+      a
+        .b do |x|
+          something
+        end
+
+      class A
+      end
+    EOF
+
+    # Check that "do" style indenting works properly for brace blocks.
+    assert_correct_indenting <<-EOF
+      a
+        .b { |x|
+          something
+        }
+
+      class A
+      end
+    EOF
+  end
+
   specify "'do' indenting" do
     assert_correct_indenting <<-EOF
       do


### PR DESCRIPTION
Allow blocks to be indented based on the `do` line by setting the
`g:ruby_indent_block_style` to `do` instead of the current default of
`expression`.

When this variable is set to `do` the following are acceptable
indentaions:

    line_one do |x|
      something
    end

    line_one
      .line_two do |x|
        something
      end

When this variable is set to `expression` the following are acceptable
indentations:

    line_one do |x|
      something
    end

    line_one
      .line_two do |x|
      something
    end

P.S: I think the `do` style is a more reasonable default, but it is not backwards-compatible. I don't know how you feel about that, but please let me know if you would like the default changed.