### PR TITLE
fix indent for closing html tag after multiline erb tag

### DIFF
--- a/indent/eruby.vim
+++ b/indent/eruby.vim
@@ -95,6 +95,7 @@ function! GetErubyIndent(...)
     let ind = ind + sw
   endif
   if line !~# '^\s*<%' && line =~# '%>\s*$' && line !~# '^\s*end\>'
+	\ && synID(v:lnum, match(cline, '\S') + 1, 1) != hlID('htmlEndTag')
     let ind = ind - sw
   endif
   if cline =~# '^\s*[-=]\=%>\s*$'

--- a/spec/indent/eruby_spec.rb
+++ b/spec/indent/eruby_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe "Indenting" do
+  specify "closing html tag after multiline eruby tag" do
+    assert_correct_indenting 'erb', <<-EOF
+      <form>
+        <div>
+          <%= text_field_tag :email, nil,
+            placeholder: "email" %>
+          text
+          <%= text_field_tag :password, nil,
+            placeholder: "password" %>
+        </div>
+      </form>
+    EOF
+  end
+end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,18 +12,20 @@ Vimrunner::RSpec.configure do |config|
     vim
   end
 
-  def assert_correct_indenting(string)
+  def assert_correct_indenting(extension='rb', string)
     whitespace = string.scan(/^\s*/).first
     string = string.split("\n").map { |line| line.gsub /^#{whitespace}/, '' }.join("\n").strip
 
-    File.open 'test.rb', 'w' do |f|
+    filename = "test.#{extension}"
+
+    File.open filename, 'w' do |f|
       f.write string
     end
 
-    vim.edit 'test.rb'
+    vim.edit filename
     vim.normal 'gg=G'
     vim.write
 
-    IO.read('test.rb').strip.should eq string
+    IO.read(filename).strip.should eq string
   end
 end


### PR DESCRIPTION
Consider this template:
```eruby
<form>
  <div>
    <%= text_field_tag :email, nil,
      placeholder: "email" %>
  </div>
</form>
```
Currently, reindenting whole file produces:
```eruby
<form>
  <div>
    <%= text_field_tag :email, nil,
      placeholder: "email" %>
</div>
</form>
```
note the closing div tag.

I'm not very familiar with vimscript, so maybe there is a better approach to detecting this situation.