### PR TITLE
Skip spawning thread in nvim

### DIFF
--- a/autoload/rubycomplete.vim
+++ b/autoload/rubycomplete.vim
@@ -587,11 +587,13 @@ class VimRubyCompletion
 # {{{ main completion code
   def self.preload_rails
     a = VimRubyCompletion.new
-    require 'Thread'
-    Thread.new(a) do |b|
-      begin
-      b.load_rails
-      rescue
+    if VIM::evaluate("has('nvim')") == 0
+      require 'thread'
+      Thread.new(a) do |b|
+        begin
+        b.load_rails
+        rescue
+        end
       end
     end
     a.load_rails


### PR DESCRIPTION
`neovim-ruby` does not support multi-threaded RPC requests, so
attempting to spawn a thread crashes the provider process (see
https://github.com/alexgenco/neovim-ruby/issues/28).

I also fixed a typo `require 'Thread'` -> `require 'thread'`
(lowercase). I'm not sure how this code could have actually worked,
since `require 'Thread'` raises a `LoadError`. If this error is getting
swallowed by the `rescue`, I would probably prefer we just get rid of
the threading logic completely, as I'm not clear what its purpose is.