### PR TITLE
Highlight colons of simple suffix-style symbols

### DIFF
--- a/syntax/ruby.vim
+++ b/syntax/ruby.vim
@@ -461,9 +461,9 @@ syn match rubyKeywordAsMethod "\(defined?\|exit!\)\@!\<[_[:lower:]][_[:alnum:]]*
 
 " More Symbols {{{1
 syn match  rubySymbol		"\%([{(,]\_s*\)\zs\l\w*[!?]\=::\@!"he=e-1
-syn match  rubySymbol		"[]})\"':]\@1<!\%(\h\|[^\x00-\x7F]\)\%(\w\|[^\x00-\x7F]\)*[!?]\=:[[:space:],]\@="he=e-1
+syn match  rubySymbol		"[]})\"':]\@1<!\%(\h\|[^\x00-\x7F]\)\%(\w\|[^\x00-\x7F]\)*[!?]\=:[[:space:],]\@="
 syn match  rubySymbol		"\%([{(,]\_s*\)\zs[[:space:],{]\l\w*[!?]\=::\@!"hs=s+1,he=e-1
-syn match  rubySymbol		"[[:space:],{(]\%(\h\|[^\x00-\x7F]\)\%(\w\|[^\x00-\x7F]\)*[!?]\=:[[:space:],]\@="hs=s+1,he=e-1
+syn match  rubySymbol		"[[:space:],{(]\%(\h\|[^\x00-\x7F]\)\%(\w\|[^\x00-\x7F]\)*[!?]\=:[[:space:],]\@="hs=s+1
 
 " __END__ Directive {{{1
 if s:foldable('__END__')


### PR DESCRIPTION
Hi folks, here's a "personal taste" patch that includes the colon in the highlighted region for suffix symbols.  It's just the difference between the following (before and after):

![wo](https://cloud.githubusercontent.com/assets/96712/24274820/be616254-108f-11e7-8091-f78ddee11db1.png)
![w](https://cloud.githubusercontent.com/assets/96712/24274816/badb6ef4-108f-11e7-8f58-bb189febb513.png)

The `he=e-1` was clearly added intentionally at some point, but I prefer both styles of symbols to look the same in this regard. (I'd also like to fix the colon highlighting on more complicated suffix symbols -- `"foo#{bar}":` and the like -- but that's much more involved than this simple patch.)

Thoughts?