### PR TITLE
allow users to override ri

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -17,3 +17,4 @@ Other contributors:
 	Aaron Son <aaronson@uiuc.edu>
 	Ned Konz <ned@bike-nomad.com>
 	Pan Thomakos <pan.thomakos@gmail.com>
+	Greg Weisbrod <greg.weisbrod@gmail.com>

--- a/ftplugin/ruby.vim
+++ b/ftplugin/ruby.vim
@@ -13,10 +13,12 @@ let b:did_ftplugin = 1
 let s:cpo_save = &cpo
 set cpo&vim
 
-if has("gui_running") && !has("gui_win32")
-  setlocal keywordprg=ri\ -T\ -f\ bs
-else
-  setlocal keywordprg=ri
+if !exists('g:ruby_keywordprg_override') || g:ruby_keywordprg_override == 0
+  if has("gui_running") && !has("gui_win32")
+    setlocal keywordprg=ri\ -T\ -f\ bs
+  else
+    setlocal keywordprg=ri
+  endif
 endif
 
 " Matchit support


### PR DESCRIPTION
I like to use `ag` or `grep` as my keywordprg program. I see that vim-ruby overrides it to `ri`. This pr adds a boolean option to prevent that.