### PR TITLE
Add motions and text-objects for Ruby do / end blocks

### DIFF
--- a/doc/vim-ruby.txt
+++ b/doc/vim-ruby.txt
@@ -12,7 +12,7 @@
 Vim provides motions such as |[m| and |]m| for jumping to the start or end of
 a method definition. Out of the box, these work for curly-bracket languages,
 but not for ruby. The |vim-ruby| plugin enhances these motions, by making them
-also work on ruby files.
+work on ruby files, and also adds a motion for working with ruby blocks.
 
 							*ruby-]m*
 ]m			Go to start of next method definition.
@@ -38,12 +38,24 @@ also work on ruby files.
 							*ruby-[]*
 []			Go to end of previous module or class definition.
 
+                                                        *ruby-]b*
+]b                      Go to start of next ruby block.
+
+                                                        *ruby-]B*
+]B                      Go to end of next ruby block.
+
+                                                        *ruby-[b*
+[b                      Go to start of previous ruby block.
+
+                                                        *ruby-[B*
+[B                      Go to end of previous ruby block.
+
 ==============================================================================
 2. Ruby text objects					*ruby-text-objects*
 
 Vim's |text-objects| can be used to select or operate upon regions of text
 that are defined by structure. The |vim-ruby| plugin adds text objects for
-operating on methods and classes.
+operating on methods, classes, and blocks.
 
 							*ruby-v_am* *ruby-am*
 am			"a method", select from "def" until matching "end"
@@ -60,6 +72,14 @@ aM			"a class", select from "class" until matching "end"
 							*ruby-v_iM* *ruby-iM*
 iM			"inner class", select contents of "class"/"end"
 			block, excluding the "class" and "end" themselves.
+
+                                                        *ruby-v_ab* *ruby-am*
+ab                      "a block", linewise select from "do" until matching
+                        "end" keyword.
+
+                                                        *ruby-v_ib* *ruby-ib*
+ib                      "inner block", select contents of "do"/"end" block,
+                        excluding the "do" and "end" themselves.
 
 ==============================================================================
 3. Access modifier indentation             *ruby-access-modifier-indentation*

--- a/ftplugin/ruby.vim
+++ b/ftplugin/ruby.vim
@@ -171,6 +171,15 @@ if !exists("g:no_plugin_maps") && !exists("g:no_ruby_maps")
   xnoremap <silent> <buffer> [M :<C-U>call <SID>searchsyn('\<end\>','rubyDefine','b','v')<CR>
   xnoremap <silent> <buffer> ]M :<C-U>call <SID>searchsyn('\<end\>','rubyDefine','','v')<CR>
 
+  nnoremap <silent> <buffer> [b :<C-U>call <SID>searchsyn('\<do\>','rubyControl','b','n')<CR>
+  nnoremap <silent> <buffer> ]b :<C-U>call <SID>searchsyn('\<do\>','rubyControl','','n')<CR>
+  nnoremap <silent> <buffer> [B :<C-U>call <SID>searchsyn('\<end\>','rubyControl','b','n')<CR>
+  nnoremap <silent> <buffer> ]B :<C-U>call <SID>searchsyn('\<end\>','rubyControl','','n')<CR>
+  xnoremap <silent> <buffer> [b :<C-U>call <SID>searchsyn('\<do\>','rubyControl','b','v')<CR>
+  xnoremap <silent> <buffer> ]b :<C-U>call <SID>searchsyn('\<do\>','rubyControl','','v')<CR>
+  xnoremap <silent> <buffer> [B :<C-U>call <SID>searchsyn('\<end\>','rubyControl','b','v')<CR>
+  xnoremap <silent> <buffer> ]B :<C-U>call <SID>searchsyn('\<end\>','rubyControl','','v')<CR>
+
   nnoremap <silent> <buffer> [[ :<C-U>call <SID>searchsyn('\<\%(class\<Bar>module\)\>','rubyModule\<Bar>rubyClass','b','n')<CR>
   nnoremap <silent> <buffer> ]] :<C-U>call <SID>searchsyn('\<\%(class\<Bar>module\)\>','rubyModule\<Bar>rubyClass','','n')<CR>
   nnoremap <silent> <buffer> [] :<C-U>call <SID>searchsyn('\<end\>','rubyModule\<Bar>rubyClass','b','n')<CR>
@@ -189,6 +198,12 @@ if !exists("g:no_plugin_maps") && !exists("g:no_ruby_maps")
     onoremap <silent> <buffer> am :<C-U>call <SID>wrap_a('[m',']M')<CR>
     xnoremap <silent> <buffer> im :<C-U>call <SID>wrap_i('[m',']M')<CR>
     xnoremap <silent> <buffer> am :<C-U>call <SID>wrap_a('[m',']M')<CR>
+
+    onoremap <silent> <buffer> ib :<C-U>call <SID>wrap_i('[b',']B')<CR>
+    onoremap <silent> <buffer> ab :<C-U>call <SID>wrap_a('[b',']B')<CR>
+    xnoremap <silent> <buffer> ib :<C-U>call <SID>wrap_i('[b',']B')<CR>
+    xnoremap <silent> <buffer> ab :<C-U>call <SID>wrap_a('[b',']B')<CR>
+
     let b:undo_ftplugin = b:undo_ftplugin
           \."| sil! exe 'ounmap <buffer> im' | sil! exe 'ounmap <buffer> am'"
           \."| sil! exe 'xunmap <buffer> im' | sil! exe 'xunmap <buffer> am'"


### PR DESCRIPTION
Not sure if others feel this belongs in vim-ruby, but I find it useful.