### PR TITLE
Highlight class level DSL as Define

### DIFF
--- a/syntax/ruby.vim
+++ b/syntax/ruby.vim
@@ -476,6 +476,8 @@ endif
 hi def link rubyClass			rubyDefine
 hi def link rubyModule			rubyDefine
 hi def link rubyMethodExceptional	rubyDefine
+hi def link rubyAccess			rubyDefine
+hi def link rubyAttribute		rubyDefine
 hi def link rubyDefine			Define
 hi def link rubyFunction		Function
 hi def link rubyConditional		Conditional
@@ -510,8 +512,6 @@ hi def link rubySymbol			Constant
 hi def link rubyKeyword			Keyword
 hi def link rubyOperator		Operator
 hi def link rubyBeginEnd		Statement
-hi def link rubyAccess			Statement
-hi def link rubyAttribute		Statement
 hi def link rubyEval			Statement
 hi def link rubyPseudoVariable		Constant
 hi def link rubyCapitalizedMethod	rubyLocalVariableOrMethod


### PR DESCRIPTION
Submitting this as a PR because I'm changing a very longstanding default and want to make sure everyone is in the loop and on board. I feel like class level DSL makes much more sense as `Define` than `Statement`. `attr_accessor` and friends are literally just wrappers around `def`. Plus, `Statement` is used for a huge percentage of things; this change balances things out a bit.