### PR TITLE
Escaped colon only seems to work inside a character class

### DIFF
--- a/ftplugin/ruby.vim
+++ b/ftplugin/ruby.vim
@@ -28,7 +28,7 @@ if exists("loaded_matchit") && !exists("b:match_words")
 	\ ':' .
 	\ '\<\%(else\|elsif\|ensure\|when\|rescue\|break\|redo\|next\|retry\)\>' .
 	\ ':' .
-        \ '\%(^\|[^.\:@$]\)\@<=\<end\:\@!\>' .
+        \ '\%(^\|[^.\:@$]\)\@<=\<end[\:]\@!\>' .
 	\ ',{:},\[:\],(:)'
 
   let b:match_skip =


### PR DESCRIPTION
At some point, `%` stopped working for me when pointing at an `end`.

Given:
```ruby
if 1
  #
else
  #
end
```

Starting at the `if` and pressing `%` jumps to the `else`, again and it jumps to the `end`... but once there, it gets stuck. (And likewise for all other block forms.)

This seems to fix that.

TBH I haven't read through matchit.vim to work out whether this change should be necessary (or is just working around a bug therein, say), but at worst it seems a pretty safe accomodation. 