### PR TITLE
Avoid highlighting operators in heredocs

### DIFF
--- a/syntax/ruby.vim
+++ b/syntax/ruby.vim
@@ -59,7 +59,13 @@ endif
 
 " Operators {{{1
 if exists("ruby_operators")
-  syn match  rubyOperator "[~!^|*/%+-]\|&\.\@!\|\%(class\s*\)\@<!<<\|<=>\|<=\|\%(<\|\<class\s\+\u\w*\s*\)\@<!<[^<]\@=\|===\|==\|=\~\|>>\|>=\|=\@1<!>\|\*\*\|\.\.\.\|\.\.\|::"
+  syn match  rubyOperator "[!^|*/%+]\|&\.\@!\|<=>\|<=\|\%(<\|\<class\s\+\u\w*\s*\)\@<!<[^<]\@=\|===\|==\|=\~\|>>\|>=\|=\@1<!>\|\*\*\|\.\.\.\|\.\.\|::"
+
+  " Special cases: "<<", "-", "~" that are not part of a heredoc delimiter
+  syn match  rubyOperator "<<\%([-~]\|\h\|[^\x00-\x7F]\|[\"'`]\)\@!"
+  syn match  rubyOperator "<<[-~]-\%(\h\|[^\x00-\x7F]\|[\"'`]\)\@!"
+  syn match  rubyOperator "\%(<<\)\@<![~-]"
+
   syn match  rubyOperator "->\|-=\|/=\|\*\*=\|\*=\|&&=\|&=\|&&\|||=\||=\|||\|%=\|+=\|!\~\|!="
   syn region rubyBracketOperator matchgroup=rubyOperator start="\%(\w[?!]\=\|[]})]\)\@2<=\[\s*" end="\s*]" contains=ALLBUT,@rubyNotTop
 endif


### PR DESCRIPTION
This PR is an attempt to fix #358, but should probably be reviewed by @tpope or @dkearns. The `<<`, `-`, and `~` operators were being highlighted as such, even when they were in heredocs.

I'm a bit fuzzy on syntax highlighting, but this seems like it fixes the issue on my local machine. Would appreciate any ideas on how it might break.