### PR TITLE
Replace `if` - `end` with `if` - `endif`

### DIFF
--- a/syntax/ruby.vim
+++ b/syntax/ruby.vim
@@ -308,7 +308,7 @@ endif
 " eRuby Config {{{1
 if exists('main_syntax') && main_syntax == 'eruby'
   let b:ruby_no_expensive = 1
-end
+endif
 
 " Module, Class, Method and Alias Declarations {{{1
 syn match  rubyAliasDeclaration    "[^[:space:];#.()]\+" contained contains=rubySymbol,rubyGlobalVariable,rubyPredefinedVariable nextgroup=rubyAliasDeclaration2 skipwhite


### PR DESCRIPTION
`end` and `endif` are equal in Vim script.
https://github.com/vim/vim/blob/833093bfb0e4a7f89b5adc66babcfa8ac09cfda9/runtime/doc/eval.txt#L10007

I think it is confusing that is using `end` instead of `endif`. And vim-ruby uses `endif` in other places. So it should be `endif`.