### PR TITLE
Disable ballonexpr by default

### DIFF
--- a/ftplugin/ruby.vim
+++ b/ftplugin/ruby.vim
@@ -13,6 +13,11 @@ let b:did_ftplugin = 1
 let s:cpo_save = &cpo
 set cpo&vim
 
+function! s:has_balloon() abort
+  return has("+balloonexpr") &&
+    \ ((has("+ballooneval") && &ballooneval) || (has("+balloonevalterm") && &balloonevalterm))
+endfunction
+
 if has("gui_running") && !has("gui_win32")
   setlocal keywordprg=ri\ -T\ -f\ bs
 else
@@ -51,8 +56,8 @@ if exists("&ofu") && has("ruby")
   setlocal omnifunc=rubycomplete#Complete
 endif
 
-" To activate, :set ballooneval
-if has('balloon_eval') && exists('+balloonexpr')
+" To activate, :set ballooneval or :set balloonevalterm
+if s:has_balloon()
   setlocal balloonexpr=RubyBalloonexpr()
 endif
 
@@ -144,7 +149,7 @@ endif
 let b:undo_ftplugin = "setl fo< inc< inex< sua< def< com< cms< path< tags< kp<"
       \."| unlet! b:browsefilter b:match_ignorecase b:match_words b:match_skip"
       \."| if exists('&ofu') && has('ruby') | setl ofu< | endif"
-      \."| if has('balloon_eval') && exists('+bexpr') | setl bexpr< | endif"
+      \."| if exists('+bexpr') | setl bexpr< | endif"
 
 function! s:map(mode, flags, map) abort
   let from = matchstr(a:map, '\S\+')


### PR DESCRIPTION
as discussed in vim/vim#3054 this will disable the balloonexpr by default and only enable it if the user has set either the 'ballooneval' or 'balloonevalterm' option. 

So it does now, what the comment above it actually says:
> To activate, :set ballooneval or :set balloonevalterm

One gotcha:
Since the check `s:has_balloon` is script-local, the check in `b:undo_ftplugin` only checks if the `balloonexpr` option exists.