### PR TITLE
Support failure without a message on the same line in rspec compiler

### DIFF
--- a/compiler/rspec.vim
+++ b/compiler/rspec.vim
@@ -24,6 +24,7 @@ CompilerSet errorformat=
     \%E%f:%l:in\ `%*[^']':\ %m,
     \%-Z\ \ \ \ \ %\\+\#\ %f:%l:%.%#,
     \%E\ \ \ \ \ Failure/Error:\ %m,
+    \%E\ \ \ \ \ Failure/Error:,
     \%C\ \ \ \ \ %m,
     \%C%\\s%#,
     \%-G%.%#


### PR DESCRIPTION
Previously we only recognized failures directly followed by a message
like so:

```
Failure/Error: expect(response).to redirect_to(store)
```

With this update we also recognize failures where the message is on the
next line like so:

```
Failure/Error:
       expect {
         put :update, params: update_params(engineer_role)
       }.to change { user.reload.role }.to(engineer_role)
```

This is my first time working with vim's `CompilerSet` format. From what i can read it's not possible to make it any more dry by making the `%m` on the existing format optional. So this was the best solution i could figure out.