### PR TITLE
Change indentation to allow (almost) any method call to precede a `def` call

### DIFF
--- a/indent/ruby.vim
+++ b/indent/ruby.vim
@@ -67,7 +67,7 @@ let s:skip_expr =
 let s:ruby_indent_keywords =
       \ '^\s*\zs\<\%(module\|class\|if\|for' .
       \   '\|while\|until\|else\|elsif\|case\|when\|unless\|begin\|ensure\|rescue' .
-      \   '\|\%(public\|protected\|private\)\=\s*def\):\@!\>' .
+      \   '\|\%([_[:lower:][:upper:]][_[:lower:][:upper:][:digit:]]*[!?]\?\)\=\s*def\):\@!\>' .
       \ '\|\%([=,*/%+-]\|<<\|>>\|:\s\)\s*\zs' .
       \    '\<\%(if\|for\|while\|until\|case\|unless\|begin\):\@!\>'
 
@@ -81,7 +81,7 @@ let s:ruby_deindent_keywords =
 let s:end_start_regex =
       \ '\C\%(^\s*\|[=,*/%+\-|;{]\|<<\|>>\|:\s\)\s*\zs' .
       \ '\<\%(module\|class\|if\|for\|while\|until\|case\|unless\|begin' .
-      \   '\|\%(public\|protected\|private\)\=\s*def\):\@!\>' .
+      \   '\|\%([_[:lower:][:upper:]][_[:lower:][:upper:][:digit:]]*[!?]\?\)\=\s*def\):\@!\>' .
       \ '\|\%(^\|[^.:@$]\)\@<=\<do:\@!\>'
 
 " Regex that defines the middle-match for the 'end' keyword.


### PR DESCRIPTION
There’s nothing special about `public`/`protected`/`private` (which were previously hard-coded), and any valid method name should be permitted.

Methods with non-letter characters won't work (e.g. `∞`), because a complete regular expression for a Ruby method name is complicated. Non-ASCII characters (e.g. `ñ`) will work.

I can’t think of any edge cases which this would break. I thought many single-line `def`s may (e.g. `def f; end; def g; end`), but as they must be separated by a `;`, it still works okay.

One note is that [vim-endwise](https://github.com/tpope/vim-endwise) should probably get a matching update as well.

Fixes #370.