### PR TITLE
Adding option for auto requiring files, and fixing #323

### DIFF
--- a/autoload/rubycomplete.vim
+++ b/autoload/rubycomplete.vim
@@ -260,6 +260,8 @@ class VimRubyCompletion
       $LOAD_PATH.concat(custom_paths).uniq!
     end
 
+    VIM::evaluate("get(g:, 'rubycomplete_auto_require', [])").each { |f| require f }
+
     buf = VIM::Buffer.current
     enum = buf.line_number
     nums = Range.new( 1, enum )

--- a/autoload/rubycomplete.vim
+++ b/autoload/rubycomplete.vim
@@ -224,7 +224,7 @@ rescue Exception
 end
 class VimRubyCompletion
 # {{{ constants
-  @@debug = true
+  @@debug = false
   @@ReservedWords = [
         "BEGIN", "END",
         "alias", "and",
@@ -360,7 +360,7 @@ class VimRubyCompletion
           next if x == 0
           ln = buf[x]
           is_const = false
-          if /^\s*(module|class|def|include)\s+/.match(ln) || is_const = /^\s*?[A-Z]([A-z]|[1-9])*\s*?[|]{0,2}=\s*?.+\s*?/.match(ln) || /attr_(accessor|reader)/.match(ln)
+          if /^\s*(module|class|def|include)\s+/.match(ln) || is_const = /^\s*?[A-Z]([A-z]|[1-9])*\s*?[|]{0,2}=\s*?.+\s*?/.match(ln) || /attr_(accessor|reader|writer)/.match(ln)
             clscnt += 1 if /class|module/.match($1)
             # We must make sure to load each constant only once to avoid errors
             if is_const

--- a/autoload/rubycomplete.vim
+++ b/autoload/rubycomplete.vim
@@ -224,7 +224,7 @@ rescue Exception
 end
 class VimRubyCompletion
 # {{{ constants
-  @@debug = false
+  @@debug = true
   @@ReservedWords = [
         "BEGIN", "END",
         "alias", "and",
@@ -360,7 +360,7 @@ class VimRubyCompletion
           next if x == 0
           ln = buf[x]
           is_const = false
-          if /^\s*(module|class|def|include)\s+/.match(ln) || is_const = /^\s*?[A-Z]([A-z]|[1-9])*\s*?[|]{0,2}=\s*?.+\s*?/.match(ln)
+          if /^\s*(module|class|def|include)\s+/.match(ln) || is_const = /^\s*?[A-Z]([A-z]|[1-9])*\s*?[|]{0,2}=\s*?.+\s*?/.match(ln) || /attr_(accessor|reader)/.match(ln)
             clscnt += 1 if /class|module/.match($1)
             # We must make sure to load each constant only once to avoid errors
             if is_const

--- a/doc/ft-ruby-omni.txt
+++ b/doc/ft-ruby-omni.txt
@@ -46,6 +46,7 @@ Notes:
 < To use custom paths that should be added to $LOAD_PATH to correctly resolve
 requires, set: >
      let g:rubycomplete_load_paths = ["/path/to/code", "./lib/example"]
-
-
+<  For automatically loading files (for example if a project has a bootstrap
+file with a bunch of require statements) set: >
+     let g:rubycomplete_auto_require = ["/path/to/file.rb", "./lib/hello.rb"]
  vim:tw=78:sw=4:ts=8:ft=help:norl:


### PR DESCRIPTION
First, this PR is an attempt to fix a constant problem I have in multiple projects. Sometimes a project has a 'bootstrap' file, or an entry point which has all the necessary require-s, and  so no need to use require statements everywhere. In this case there will be no completion.

A possible solution is to use an option to set an array of files which are always required, so it'll work.

The other, is a fix for #323   