### PR TITLE
Fix missing comma in `indent/ruby.vim` in `s:syng_strcom` list

### DIFF
--- a/indent/ruby.vim
+++ b/indent/ruby.vim
@@ -58,7 +58,7 @@ let s:syng_stringdoc = s:syng_string + ['Documentation']
 " Syntax group names that are or delimit strings/symbols/regexes or are comments.
 let s:syng_strcom = s:syng_stringdoc + [
       \ 'Character',
-      \ 'Comment'
+      \ 'Comment',
       \ 'HeredocDelimiter',
       \ 'PercentRegexpDelimiter',
       \ 'PercentStringDelimiter',


### PR DESCRIPTION
Hello! Today I've updated my vim plugins and noticed that there had been an error introduced in [one of the latest commits](https://github.com/vim-ruby/vim-ruby/commit/eec4d8957df77220632f040fecc3c42e11ff7bdd#diff-bca3ba1cf5f64360a6ba030a95a6e902R61).
After the fix the plugin seems to be working OK. :grin:

Thanks for maintaining this project and have a nice day!
Stay awesome! 😎 