### PR TITLE
Automatically detect Sorbet RBI files as Ruby files

### DIFF
--- a/ftdetect/ruby_extra.vim
+++ b/ftdetect/ruby_extra.vim
@@ -57,6 +57,9 @@ au BufNewFile,BufRead [rR]outefile		call s:setf('ruby')
 " SimpleCov
 au BufNewFile,BufRead .simplecov		call s:setf('ruby')
 
+" Sorbet RBI files
+au BufNewFile,BufRead *.rbi		        call s:setf('ruby')
+
 " Thor
 au BufNewFile,BufRead [tT]horfile,*.thor	call s:setf('ruby')
 


### PR DESCRIPTION
The Sorbet type checker allows writing "Ruby Interface" files in order to learn Sorbet about what classes are defined and what are interfaces of the methods. The RBI files are pure Ruby files by [definition](https://sorbet.org/docs/rbi#syntax). Hence, it would be nice to set the filetype to `ruby` automatically once the RBI file is opened.