### PR TITLE
Handle empty `$HOME` in ftplugin

### DIFF
--- a/ftplugin/ruby.vim
+++ b/ftplugin/ruby.vim
@@ -111,7 +111,7 @@ else
   if !exists('g:ruby_default_path')
     if has("ruby") && has("win32")
       ruby ::VIM::command( 'let g:ruby_default_path = split("%s",",")' % $:.join(%q{,}) )
-    elseif executable('ruby')
+    elseif executable('ruby') && !empty($HOME)
       let g:ruby_default_path = s:query_path($HOME)
     else
       let g:ruby_default_path = map(split($RUBYLIB,':'), 'v:val ==# "." ? "" : v:val')


### PR DESCRIPTION
Noticed this with `env -u HOME vim …`, where `exe 'cd'` with an empty
string then would fail (due to missing `$HOME` also).

https://github.com/vim/vim/blob/7306d6/runtime/ftplugin/ruby.vim#L79