### PR TITLE
Try fixing a memory-intensive pattern

### DIFF
--- a/spec/syntax/maxmempattern_limit_spec.rb
+++ b/spec/syntax/maxmempattern_limit_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe "Maxmempattern limit" do
+  specify "maxmempattern=1000 is enough even for long strings" do
+    str = <<~'EOF'
+      hash = {
+        "A-NOT-Managed-Strings" => "ABCDEfghe910dmckamks019292djdjOOOjjjd/cr3wdCA+1n/xHfHMgG+cC0EoUNngcBjgWvBMEF1CurBwTtDswJjQYa5wYRAQEBAQECCwGwAQEvI50CnwMNAwRrAQYBr9PPAoK7sQMBAQMCBAkICAQIAwEBAwYBAQQFFQEBAhQDAwMDCwEBAQUBAQHGAQEWBAEBDecBfS8CHQEKkAEMMxcMCQoUDwYHIjd3DQ4MFk0JWGYALSKLAQOLAYEBFBAjCBGDAQICAgMANjsZAg9fCxkCgLZKAwSEAQIBiwEZGAsrBCgFMmUEJShyFSfRBQEOSQY62AG0AVlCrQ",
+      }
+    EOF
+    assert_correct_highlighting str, %w[ABCDE], 'rubyString'
+  end
+end

--- a/syntax/ruby.vim
+++ b/syntax/ruby.vim
@@ -461,7 +461,7 @@ endif
 syn match rubyDefinedOperator "\%#=1\<defined?" display
 
 " 1.9-style Hash Keys and Keyword Parameters {{{1
-syn match rubySymbol "\%([{(|,]\_s*\)\@<=\%(\h\|[^\x00-\x7F]\)\%(\w\|[^\x00-\x7F]\)*[?!]\=::\@!"he=e-1
+syn match rubySymbol "\%(\w\|[^\x00-\x7F]\)\%(\w\|[^\x00-\x7F]\)*[?!]\=::\@!"he=e-1 contained containedin=rubyBlockParameterList,rubyCurlyBlock
 syn match rubySymbol "[]})\"':]\@1<!\<\%(\h\|[^\x00-\x7F]\)\%(\w\|[^\x00-\x7F]\)*[!?]\=:[[:space:],;]\@="he=e-1
 syn match rubySymbol "[[:space:],{(]\%(\h\|[^\x00-\x7F]\)\%(\w\|[^\x00-\x7F]\)*[!?]\=:[[:space:],;]\@="hs=s+1,he=e-1
 


### PR DESCRIPTION
This particular pattern matches symbols in hashes and block argument lists (it seems), so that's the places we'll say it's contained.

More explanations in: https://github.com/vim-ruby/vim-ruby/issues/412