### PR TITLE
New parameter rubycomplete_add_local_paths

### DIFF
--- a/autoload/rubycomplete.vim
+++ b/autoload/rubycomplete.vim
@@ -50,6 +50,10 @@ endif
 if !exists("g:rubycomplete_include_objectspace")
     let g:rubycomplete_include_objectspace = 0
 endif
+
+if !exists("g:rubycomplete_add_local_paths")
+    let g:rubycomplete_add_local_paths = 1
+endif
 " }}} configuration failsafe initialization
 
 " {{{ regex patterns
@@ -498,12 +502,17 @@ class VimRubyCompletion
     end
 
     return if rails_base == nil
+
     $:.push rails_base unless $:.index( rails_base )
 
     rails_config = rails_base + "config/"
     rails_lib = rails_base + "lib/"
-    $:.push rails_config unless $:.index( rails_config )
-    $:.push rails_lib unless $:.index( rails_lib )
+
+    add_local_paths = VIM::evaluate("exists('g:rubycomplete_add_local_paths') && g:rubycomplete_add_local_paths")
+    if !add_local_paths.to_i.zero?
+        $:.push rails_config unless $:.index( rails_config )
+        $:.push rails_lib unless $:.index( rails_lib )
+    end
 
     bootfile = rails_config + "boot.rb"
     envfile = rails_config + "environment.rb"

--- a/doc/ft-ruby-omni.txt
+++ b/doc/ft-ruby-omni.txt
@@ -36,7 +36,10 @@ Notes:
    project.  The feature is disabled by default, to enable it add >
      let g:rubycomplete_rails = 1
 <   to your vimrc
- - Vim can parse a Gemfile, in case gems are being implicitly required.  To
+ - The rails completion feature adds the lib and config path to LOAD_PATH.
+   To disable this add >
+     let g:rubycomplete_add_local_paths = 0
+< - Vim can parse a Gemfile, in case gems are being implicitly required.  To
    activate the feature: >
      let g:rubycomplete_load_gemfile = 1
 <   To specify an alternative path, use: >


### PR DESCRIPTION
By default rails completion loads the config and lib path.
With this parameter this can be disabled
Fixes vim-ruby/vim-ruby#414

By default there are no changes.
Only if you add `let g:rubycomplete_add_local_paths = 0` to your .vimrc the loading will be disabled.
