### PR TITLE
Fix b:undo_ftplugin on eruby

### DIFF
--- a/ftplugin/eruby.vim
+++ b/ftplugin/eruby.vim
@@ -117,7 +117,7 @@ endif
 " TODO: comments=
 setlocal commentstring=<%#%s%>
 
-let b:undo_ftplugin = "setl cms< "
+let b:undo_ftplugin = "setl cms< | setl path< "
       \ " | unlet! b:browsefilter b:match_words | " . s:undo_ftplugin
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
`b:undo_ftplugin` didn't reset the path to the default, so fix the problem that the path is set repeatedly.

neovim/neovim#12562