### PR TITLE
Add option to avoid hanging indents

### DIFF
--- a/doc/ft-ruby-indent.txt
+++ b/doc/ft-ruby-indent.txt
@@ -4,6 +4,7 @@ RUBY							*ft-ruby-indent*
     Ruby: Access modifier indentation	|ruby-access-modifier-indentation|
     Ruby: Block style indentation	|ruby-block-style-indentation|
     Ruby: Assignment style indentation	|ruby-assignment-style-indentation|
+    Ruby: Hanging element indentation	|ruby-hanging-element-indentation|
 
 					*ruby-access-modifier-indentation*
 					*g:ruby_indent_access_modifier_style*
@@ -106,5 +107,33 @@ Assignment indent style "variable":
     end
 <
 
+					*ruby-hanging-element-indentation*
+					*g:ruby_indent_hanging_elements*
+    Ruby: Hanging element indentation ~
+
+Elements of multiline collections -- such as arrays, hashes, and method
+argument lists -- can have hanging indentation enabled or disabled with the
+following setting.
+>
+    :let g:ruby_indent_hanging_elements = 1
+    :let g:ruby_indent_hanging_elements = 0
+<
+By default, this setting is "1" (true) meaning that hanging indentation is
+enabled.
+
+Here is an example method call when the setting is true (non-zero):
+>
+    render('product/show',
+           product: product,
+           on_sale: true,
+          )
+<
+And the same method call when the setting is false (zero):
+>
+    render('product/show',
+      product: product,
+      on_sale: true,
+    )
+<
 
  vim:tw=78:sw=4:ts=8:ft=help:norl:

--- a/indent/ruby.vim
+++ b/indent/ruby.vim
@@ -29,6 +29,11 @@ if !exists('g:ruby_indent_block_style')
   let g:ruby_indent_block_style = 'do'
 endif
 
+if !exists('g:ruby_indent_hanging_elements')
+  " Non-zero means hanging indents are enabled, zero means disabled
+  let g:ruby_indent_hanging_elements = 1
+endif
+
 setlocal nosmartindent
 
 " Now, set up our indentation expression and keys that trigger it.
@@ -321,7 +326,11 @@ function! s:ClosingBracketOnEmptyLine(cline_info) abort
 
     if searchpair(escape(bracket_pair[0], '\['), '', bracket_pair[1], 'bW', s:skip_expr) > 0
       if closing_bracket == ')' && col('.') != col('$') - 1
-        let ind = virtcol('.') - 1
+        if g:ruby_indent_hanging_elements
+          let ind = virtcol('.') - 1
+        else
+          let ind = indent(line('.'))
+        end
       elseif g:ruby_indent_block_style == 'do'
         let ind = indent(line('.'))
       else " g:ruby_indent_block_style == 'expression'
@@ -546,7 +555,9 @@ function! s:AfterUnbalancedBracket(pline_info) abort
     let [opening, closing] = s:ExtraBrackets(info.plnum)
 
     if opening.pos != -1
-      if opening.type == '(' && searchpair('(', '', ')', 'bW', s:skip_expr) > 0
+      if !g:ruby_indent_hanging_elements
+        return indent(info.plnum) + info.sw
+      elseif opening.type == '(' && searchpair('(', '', ')', 'bW', s:skip_expr) > 0
         if col('.') + 1 == col('$')
           return indent(info.plnum) + info.sw
         else

--- a/spec/indent/blocks_spec.rb
+++ b/spec/indent/blocks_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
 describe "Indenting" do
-  after :each do
-    vim.command 'let g:ruby_indent_block_style = "expression"'
-  end
-
   specify "indented blocks with expression style" do
     vim.command 'let g:ruby_indent_block_style = "expression"'
 
@@ -103,6 +99,7 @@ describe "Indenting" do
   end
 
   specify "blocks with multiline parameters" do
+    vim.command 'let g:ruby_indent_block_style = "expression"'
     assert_correct_indenting <<~EOF
       def foo
         opts.on('--coordinator host=HOST[,port=PORT]',

--- a/spec/indent/continuations_spec.rb
+++ b/spec/indent/continuations_spec.rb
@@ -57,6 +57,7 @@ describe "Indenting" do
   end
 
   specify "continuations after round braces" do
+    vim.command 'let g:ruby_indent_block_style = "expression"'
     assert_correct_indenting <<~EOF
       opts.on('--coordinator host=HOST[,port=PORT]',
               'Specify the HOST and the PORT of the coordinator') do |str|
@@ -67,10 +68,6 @@ describe "Indenting" do
   end
 
   describe "assignments" do
-    after :each do
-      vim.command 'let g:ruby_indent_assignment_style = "hanging"'
-    end
-
     specify "continuations after assignment" do
       assert_correct_indenting <<~EOF
         variable =

--- a/spec/indent/hanging_elements_spec.rb
+++ b/spec/indent/hanging_elements_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+
+describe 'Indenting' do
+
+  specify 'method args' do
+    assert_correct_indenting <<~EOF
+      render('product/show',
+             product: product,
+             on_sale: true,
+            )
+    EOF
+
+    vim.command 'let g:ruby_indent_hanging_elements = 0'
+
+    assert_correct_indenting <<~EOF
+      render('product/show',
+        product: product,
+        on_sale: true,
+      )
+    EOF
+  end
+
+  specify 'method args with block' do
+    assert_correct_indenting <<~EOF
+      opts.on('--coordinator host=HOST[,port=PORT]',
+              'Specify the HOST and the PORT of the coordinator') do |str|
+                h = sub_opts_to_hash(str)
+                puts h
+              end
+    EOF
+
+    vim.command 'let g:ruby_indent_hanging_elements = 0'
+
+    assert_correct_indenting <<~EOF
+      opts.on('--coordinator host=HOST[,port=PORT]',
+        'Specify the HOST and the PORT of the coordinator') do |str|
+          h = sub_opts_to_hash(str)
+          puts h
+        end
+    EOF
+  end
+
+  specify 'arrays' do
+    assert_correct_indenting <<~EOF
+      x = [1,
+           2,
+           3,
+      ]
+    EOF
+
+    vim.command 'let g:ruby_indent_hanging_elements = 0'
+
+    assert_correct_indenting <<~EOF
+      x = [1,
+        2,
+        3,
+      ]
+    EOF
+  end
+
+  specify 'hashes' do
+    assert_correct_indenting <<~EOF
+      x = { a: 1,
+            b: 2,
+            c: 3,
+      }
+    EOF
+
+    vim.command 'let g:ruby_indent_hanging_elements = 0'
+
+    assert_correct_indenting <<~EOF
+      x = { a: 1,
+        b: 2,
+        c: 3,
+      }
+    EOF
+  end
+end

--- a/spec/indent/indent_access_modifier_spec.rb
+++ b/spec/indent/indent_access_modifier_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
 
 describe "Indenting" do
-  after :each do
-    vim.command 'let g:ruby_indent_access_modifier_style = "normal"'
-  end
-
   specify "default indented access modifiers" do
     assert_correct_indenting <<~EOF
       class OuterClass

--- a/spec/indent/nesting_spec.rb
+++ b/spec/indent/nesting_spec.rb
@@ -20,6 +20,7 @@ describe "Indenting" do
       }
     EOF
 
+    vim.command 'let g:ruby_indent_block_style = "expression"'
     assert_correct_indenting <<~EOF
       var.
         func1(:param => 'value') {
@@ -40,6 +41,7 @@ describe "Indenting" do
       }
     EOF
 
+    vim.command 'let g:ruby_indent_block_style = "expression"'
     assert_correct_indenting <<~EOF
       foo,
         bar = {
@@ -53,6 +55,7 @@ describe "Indenting" do
   end
 
   specify "nested blocks with a continuation and function call inbetween" do
+    vim.command 'let g:ruby_indent_block_style = "expression"'
     assert_correct_indenting <<~EOF
       var.
         func1(:param => 'value') {

--- a/spec/indent/splat_spec.rb
+++ b/spec/indent/splat_spec.rb
@@ -20,6 +20,7 @@ describe "Indenting" do
   end
 
   specify "splats with blocks in assignment" do
+    vim.command 'let g:ruby_indent_block_style = "expression"'
     assert_correct_indenting <<~EOF
       x = *
         array.map do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@ RSpec.configure do |config|
     vim.command 'let g:ruby_indent_access_modifier_style = "normal"'
     vim.command 'let g:ruby_indent_block_style = "do"'
     vim.command 'let g:ruby_indent_assignment_style = "hanging"'
+    vim.command 'let g:ruby_indent_hanging_elements = 1'
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,15 @@
 require 'vimrunner'
 require 'vimrunner/rspec'
 
+RSpec.configure do |config|
+  # reset globals to default values before each test
+  config.before(:each) do
+    vim.command 'let g:ruby_indent_access_modifier_style = "normal"'
+    vim.command 'let g:ruby_indent_block_style = "do"'
+    vim.command 'let g:ruby_indent_assignment_style = "hanging"'
+  end
+end
+
 Vimrunner::RSpec.configure do |config|
   config.reuse_server = true
 


### PR DESCRIPTION
The executive summary is that this PR adds a global setting to indent like this:

```
render('product/show',
  product: product,
  on_sale: true,
)
```

The PR includes documentation and tests. The whole test suite still passes. With the default value, it should not affect current indenting behaviour at all.

The first commit is a small refactoring of the indentation specs. Half of these were failing when run as individual files, because they relied upon global state being modified in other files. I just made it so every test starts with the globals set to their default value, automatically.

I tried to stick to the conventions I found in the project, but I'm open to making changes.