### PR TITLE
Nested parens in symbols

### DIFF
--- a/spec/syntax/symbols_spec.rb
+++ b/spec/syntax/symbols_spec.rb
@@ -42,4 +42,12 @@ describe "Syntax highlighting" do
       validates_inclusion_of :gender, in: %w(male female), if: :gender_required?
     EOF
   end
+
+  specify "nested parentheses inside symbols" do
+    assert_correct_highlighting <<~EOF, 'bar\zs)', 'rubyNestedParentheses'
+      h = %i(
+        foo(bar)baz
+      )
+    EOF
+  end
 end

--- a/spec/syntax/symbols_spec.rb
+++ b/spec/syntax/symbols_spec.rb
@@ -44,7 +44,7 @@ describe "Syntax highlighting" do
   end
 
   specify "nested parentheses inside symbols" do
-    assert_correct_highlighting <<~EOF, 'bar\zs)', 'rubyNestedParentheses'
+    assert_correct_highlighting <<~EOF, 'bar\zs)', 'rubySymbol'
       h = %i(
         foo(bar)baz
       )

--- a/spec/vim/plugin/syntax_test.vim
+++ b/spec/vim/plugin/syntax_test.vim
@@ -2,7 +2,7 @@
 let s:debug = 0
 
 function! s:CursorHasGroup(group) abort
-  return synIDattr(synID(line('.'), col('.'), 0), 'name') =~ a:group
+  return synIDattr(synID(line('.'), col('.'), 1), 'name') =~ a:group
 endfunction
 
 function! TestSyntax(pattern, group) abort

--- a/syntax/ruby.vim
+++ b/syntax/ruby.vim
@@ -133,10 +133,10 @@ syn match rubyCurlyBraceEscape	  "\\[{}]"  contained display
 syn match rubyAngleBracketEscape  "\\[<>]"  contained display
 syn match rubySquareBracketEscape "\\[[\]]" contained display
 
-syn region rubyNestedParentheses    start="("  skip="\\\\\|\\)"  matchgroup=rubyString end=")"	transparent contained
-syn region rubyNestedCurlyBraces    start="{"  skip="\\\\\|\\}"  matchgroup=rubyString end="}"	transparent contained
-syn region rubyNestedAngleBrackets  start="<"  skip="\\\\\|\\>"  matchgroup=rubyString end=">"	transparent contained
-syn region rubyNestedSquareBrackets start="\[" skip="\\\\\|\\\]" matchgroup=rubyString end="\]"	transparent contained
+syn region rubyNestedParentheses    start="("  skip="\\\\\|\\)"  end=")"	transparent contained
+syn region rubyNestedCurlyBraces    start="{"  skip="\\\\\|\\}"  end="}"	transparent contained
+syn region rubyNestedAngleBrackets  start="<"  skip="\\\\\|\\>"  end=">"	transparent contained
+syn region rubyNestedSquareBrackets start="\[" skip="\\\\\|\\\]" end="\]"	transparent contained
 
 syn cluster rubySingleCharEscape contains=rubyBackslashEscape,rubyQuoteEscape,rubySpaceEscape,rubyParenthesisEscape,rubyCurlyBraceEscape,rubyAngleBracketEscape,rubySquareBracketEscape
 syn cluster rubyNestedBrackets	 contains=rubyNested.\+


### PR DESCRIPTION
There's a syntax bug with nested parentheses in symbols. Here's an example:

``` ruby
h = %i(
  foo(bar)baz
)
```

The closing bracket after `bar` is actually highlighted as `rubyString` while everything else inside `%i(` is a `rubySymbol`. 

It seems like one way to solve this is to just remove the `matchgroup=rubyString`. From what I understand, the only reason the nested groups exist is to ensure that closing brackets are not confused, but we should be able to leave them "transparent" for the syntax engine.

Would appreciate a review by @dkearns in particular for the test tweak.