### PR TITLE
Add highlighting for shareable_constant_value

### DIFF
--- a/spec/syntax/comments_spec.rb
+++ b/spec/syntax/comments_spec.rb
@@ -40,6 +40,12 @@ describe "Syntax highlighting" do
     EOF
   end
 
+  specify "magic comments - shareable_constant_value" do
+    assert_correct_highlighting <<~'EOF', 'shareable_constant_value', 'rubyMagicComment'
+      # shareable_constant_value: literal
+    EOF
+  end
+
   specify "TODO comments" do
     assert_correct_highlighting <<~'EOF', 'TODO', 'rubyTodo'
       # TODO: turn off the oven

--- a/syntax/ruby.vim
+++ b/syntax/ruby.vim
@@ -429,9 +429,10 @@ endif
 " Comments and Documentation {{{1
 syn match   rubySharpBang    "\%^#!.*" display
 syn keyword rubyTodo	     FIXME NOTE TODO OPTIMIZE HACK REVIEW XXX todo contained
-syn match   rubyEncoding     "[[:alnum:]-]\+" contained display
+syn match   rubyEncoding     "[[:alnum:]-_]\+" contained display
 syn match   rubyMagicComment "\c\%<3l#\s*\zs\%(coding\|encoding\):"					contained nextgroup=rubyEncoding skipwhite
 syn match   rubyMagicComment "\c\%<10l#\s*\zs\%(frozen_string_literal\|warn_indent\|warn_past_scope\):" contained nextgroup=rubyBoolean  skipwhite
+syn match   rubyMagicComment "\c\%<10l#\s*\zs\%(shareable_constant_value\):"				contained nextgroup=rubyEncoding  skipwhite
 syn match   rubyComment	     "#.*" contains=@rubyCommentSpecial,rubySpaceError,@Spell
 
 syn cluster rubyCommentSpecial contains=rubySharpBang,rubyTodo,rubyMagicComment


### PR DESCRIPTION
Ruby 3.0.0 added a new magic comment for making different literals
"shareable" (a.k.a frozen).

Here is a link to the docs: https://github.com/ruby/ruby/blob/cfbf2bde4002821d12047b2aba0010739aaf925e/doc/syntax/comments.rdoc#label-shareable_constant_value+Directive

Here's a demo of the feature:

```
  $ cat test.rb
  # shareable_constant_value: literal

  FOO = [ 1, 2, 3 ]

  p FOO.frozen?
  $ ruby test.rb
  true
```