### PR TITLE
Wait for space after `in` to indent in insert mode

### DIFF
--- a/indent/ruby.vim
+++ b/indent/ruby.vim
@@ -39,7 +39,7 @@ setlocal nosmartindent
 " Now, set up our indentation expression and keys that trigger it.
 setlocal indentexpr=GetRubyIndent(v:lnum)
 setlocal indentkeys=0{,0},0),0],!^F,o,O,e,:,.
-setlocal indentkeys+==end,=else,=elsif,=when,=in,=ensure,=rescue,==begin,==end
+setlocal indentkeys+==end,=else,=elsif,=when,=in\ ,=ensure,=rescue,==begin,==end
 setlocal indentkeys+==private,=protected,=public
 
 let b:undo_indent = "setlocal indentexpr< indentkeys< smartindent<"

--- a/spec/indent/case_in_spec.rb
+++ b/spec/indent/case_in_spec.rb
@@ -17,4 +17,13 @@ describe "Indenting" do
       end #=> true
     EOF
   end
+
+  specify "does not deindent while typing" do
+    assert_correct_indent_in_insert 'rb', <<~EOF, "index = 0", <<~RESULT
+      def foo
+    EOF
+      def foo
+        index = 0
+    RESULT
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,6 +35,19 @@ Vimrunner::RSpec.configure do |config|
     expect(IO.read(filename)).to eq string
   end
 
+  def assert_correct_indent_in_insert(extension='rb', content, input, result)
+    filename = "test.#{extension}"
+
+    IO.write filename, content
+
+    vim.edit filename
+    vim.normal 'Go'
+    vim.feedkeys input
+    vim.write
+
+    expect(IO.read(filename)).to eq result
+  end
+
   def assert_correct_highlighting(extension='rb', string, patterns, group)
     filename = "test.#{extension}"
 


### PR DESCRIPTION
Since de3d94917942496d3782e564b3779a2600b18a15, the `in` keyword is properly de-indented, but I find it very annoying when typing anything starting with `in` but not in the context of a `case` statement, most often with a variable called `index`.

Technically we could do something similar for `elsif`, `when`, but I rarely encounter the same issue with those so I'm not sure it's worth changing.