### PR TITLE
Stop using deprecated File.exists?

### DIFF
--- a/autoload/rubycomplete.vim
+++ b/autoload/rubycomplete.vim
@@ -488,7 +488,7 @@ class VimRubyCompletion
         trail = "%s%s" % [ dir, sub ]
         tcfg = "%sconfig" % trail
 
-        if File.exists?( tcfg )
+        if File.exist?( tcfg )
           rails_base = trail
           break
         end
@@ -501,7 +501,7 @@ class VimRubyCompletion
 
     bootfile = rails_base + "config/boot.rb"
     envfile = rails_base + "config/environment.rb"
-    if File.exists?( bootfile ) && File.exists?( envfile )
+    if File.exist?( bootfile ) && File.exist?( envfile )
       begin
         require bootfile
         require envfile


### PR DESCRIPTION
Hello!

Just a quick fix on the Ruby code.

`File.exists?` was removed on Ruby 3.2.0:

* https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/
* https://bugs.ruby-lang.org/issues/17391

So if you `let g:rubycomplete_rails=1` and `C-X C-O`

```
Error detected while processing function rubycomplete#Complete[22]..provider#ruby#Call[17]..rubycomplete#Complete:
line   22:
NoMethodError: undefined method `exists?' for File:Class
```

The PR just uses `File.exist?` instead. Method does the same and has been present at least since Ruby 1.8.6:

* https://ruby-doc.org/core-1.8.6/File.html#method-c-exist-3F
