### PR TITLE
ftdetect: add .rvmrc

### DIFF
--- a/ftdetect/ruby_extra.vim
+++ b/ftdetect/ruby_extra.vim
@@ -57,6 +57,10 @@ au BufNewFile,BufRead *.rabl			call s:setf('ruby')
 " Routefile
 au BufNewFile,BufRead [rR]outefile		call s:setf('ruby')
 
+" RVM
+au BufNewFile,BufRead .rvmrc			call s:setf('sh')
+au BufNewFile,BufRead rvmrc			call s:setf('sh')
+
 " SimpleCov
 au BufNewFile,BufRead .simplecov		call s:setf('ruby')
 


### PR DESCRIPTION
The `.rvmrc` file is used for configuring RVM (rvm.io).

Documentation: https://rvm.io/workflow/rvmrc