### PR TITLE
ftdetect: detect gemrc files

### DIFF
--- a/ftdetect/ruby_extra.vim
+++ b/ftdetect/ruby_extra.vim
@@ -30,6 +30,10 @@ au BufNewFile,BufRead Berksfile			call s:setf('ruby')
 " CocoaPods
 au BufNewFile,BufRead Podfile,*.podspec		call s:setf('ruby')
 
+" Gem
+au BufNewFile,BufRead gemrc			call s:setf('yaml')
+au BufNewFile,BufRead .gemrc			call s:setf('yaml')
+
 " Guard
 au BufNewFile,BufRead Guardfile,.Guardfile	call s:setf('ruby')
 


### PR DESCRIPTION
This file is used by RubyGems for configuration.

Documentation: https://guides.rubygems.org/command-reference/#description-6